### PR TITLE
feature: Added support for X-Forwarded-For chains

### DIFF
--- a/pkg/server/middlewares.go
+++ b/pkg/server/middlewares.go
@@ -55,8 +55,8 @@ func (s *Server) MiddlewareProxyHeaders(c *gin.Context) {
 	xForwardedPort := c.Request.Header.Get("X-Forwarded-Port")
 
 	// Split the X-Forwarded-For header to get the originating client IP
-	ips := strings.Split(xForwardedFor, ",")
-	clientIP := strings.TrimSpace(ips[0])
+	clientIP, _, _ := strings.Cut(xForwardedFor, ",")
+	clientIP = strings.TrimSpace(clientIP)
 
 	// Get and validate the remote address
 	_, err := netip.ParseAddrPort(net.JoinHostPort(clientIP, xForwardedPort))

--- a/pkg/server/middlewares.go
+++ b/pkg/server/middlewares.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/netip"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -42,18 +43,23 @@ func (s *Server) MiddlewareRequireClientCertificate(c *gin.Context) {
 // This middleware should be used first in the chain.
 func (s *Server) MiddlewareProxyHeaders(c *gin.Context) {
 	// Ensure required headers are present
-	for i := range proxyHeaders {
-		if c.Request.Header.Get(proxyHeaders[i]) == "" {
-			AbortWithError(c, NewResponseErrorf(http.StatusBadRequest, "Missing header %s", proxyHeaders[i]))
+	for _, header := range proxyHeaders {
+		if c.Request.Header.Get(header) == "" {
+			AbortWithError(c, NewResponseErrorf(http.StatusBadRequest, "Missing header %s", header))
 			return
 		}
 	}
 
+	// Get the X-Forwarded-For header
+	xForwardedFor := c.Request.Header.Get("X-Forwarded-For")
+	xForwardedPort := c.Request.Header.Get("X-Forwarded-Port")
+
+	// Split the X-Forwarded-For header to get the originating client IP
+	ips := strings.Split(xForwardedFor, ",")
+	clientIP := strings.TrimSpace(ips[0])
+
 	// Get and validate the remote address
-	_, err := netip.ParseAddrPort(net.JoinHostPort(
-		c.Request.Header.Get("X-Forwarded-For"),
-		c.Request.Header.Get("X-Forwarded-Port"),
-	))
+	_, err := netip.ParseAddrPort(net.JoinHostPort(clientIP, xForwardedPort))
 	if err != nil {
 		AbortWithError(c, NewResponseErrorf(http.StatusBadRequest, "Invalid remote address and port: %v", err))
 		return


### PR DESCRIPTION
Fixes: https://github.com/ItalyPaleAle/traefik-forward-auth/issues/5

### What 

Added support to be able to correctly obtain the originating…Ip from the X-Forwaded-For header when using a chain of IPs

### Why 

Previous behaviour would cause the application to error due to it being unable to handle chains.
```
Invalid remote address and port: ParseAddr(\"5.5.5.5, 10.42.6.100\")
```
### How

When using the X-Forwarded-For header the originating client ip should always be the first item in the chain, followed by the proxy ips.
Therefor, by parsing the `X-Forwarded-For` chain into an array using a comma delimiter and using the first item as the originating IP