### PR TITLE
feat: allow websockets, map protocol to http(s) if redirecting

### DIFF
--- a/pkg/server/middlewares.go
+++ b/pkg/server/middlewares.go
@@ -71,10 +71,10 @@ func (s *Server) MiddlewareProxyHeaders(c *gin.Context) {
 
 	// Validate X-Forwarded-Proto
 	switch c.Request.Header.Get("X-Forwarded-Proto") {
-	case "http", "https":
+	case "http", "https", "ws", "wss":
 		// All good
 	default:
-		AbortWithError(c, NewResponseError(http.StatusBadRequest, "Invalid value for the 'X-Forwarded-Proto' header: must be 'http' or 'https'"))
+		AbortWithError(c, NewResponseError(http.StatusBadRequest, "Invalid value for the 'X-Forwarded-Proto' header: must be 'http', 'https', 'ws', or 'wss'"))
 		return
 	}
 


### PR DESCRIPTION
I'd found that anything using WebSockets was failing when behind traefik-forward-auth, as the X-Forwarded-Proto was not http or https. In the interim I worked around the issue by adding an additional `headers` middleware before the `forwardAuth` to force it to be `https`:
```
  headers:
    customRequestHeaders:
      X-Forwarded-Proto: "https"
```

However this isn't ideal for obvious reasons. This PR allows traefik-forward-auth to accept websockets as X-Forwarded-Proto, and will map to the HTTP(S) equivalents should it need to redirect. Let me know if I've misunderstood anything, though it seems to work for me.