### PR TITLE
fix(logging): correct log level parsing

### DIFF
--- a/cmd/traefik-forward-auth/config.go
+++ b/cmd/traefik-forward-auth/config.go
@@ -86,7 +86,7 @@ func getLogger(cfg *config.Config) (log *slog.Logger, shutdownFn func(ctx contex
 	case isatty.IsTerminal(os.Stdout.Fd()):
 		// Enable colors if we have a TTY
 		handler = tint.NewHandler(os.Stdout, &tint.Options{
-			Level:      slog.LevelDebug,
+			Level:      level,
 			TimeFormat: time.StampMilli,
 		})
 	default:


### PR DESCRIPTION
At present the log level is not respected by all messages, for example with the log level set to warn you still get these info messages:

```
time=2025-08-12T03:11:58.871Z level=INFO msg="HTTP Request" app=traefik-forward-auth version=3.6.0 id=6ba1e926-6159-459e-8772-fd90f9aa0e99 status=200 method=GET path=/ client=172.19.0.1 duration=0.142 respSize=62 traefik=f85a98a186f7
time=2025-08-12T03:12:54.257Z level=INFO msg="HTTP Request" app=traefik-forward-auth version=3.6.0 id=a7b5fd31-ebe0-4457-a43b-b564b5dbd7f0 status=200 method=GET path=/ client=172.19.0.1 duration=0.183 respSize=62 traefik=f85a98a186f7
time=2025-08-12T03:13:54.557Z level=INFO msg="HTTP Request" app=traefik-forward-auth version=3.6.0 id=f0fcce6c-4019-4e02-a698-6303bae8eb51 status=200 method=GET path=/ client=172.19.0.1 duration=0.154 respSize=62 traefik=f85a98a186f7
```

@ItalyPaleAle Looking at the code I see one of the log level parameters was using `slog.LevelDebug` hardcoded, this PR correct the parameter to use the configured log level.