### PR TITLE
Add response header customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ ghcr.io/italypaleale/traefik-forward-auth:4.x.x
   - [Observability: Logs, Traces, Metrics](./docs/07-advanced-configuration.md#observability-logs-traces-metrics)
   - [Token signing keys](./docs/07-advanced-configuration.md#token-signing-keys)
   - [Configure session lifetime](./docs/07-advanced-configuration.md#configure-session-lifetime)
+  - [Configure headers](./docs/07-advanced-configuration.md#configure-headers)
   - [Security hardening](./docs/07-advanced-configuration.md#security-hardening)
   - [Container health checks](./docs/07-advanced-configuration.md#container-health-checks)
 - [**📍 Endpoints**](./docs/08-endpoints.md)

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -669,3 +669,25 @@ portals:
           ##   Defaults to the standard color for the provider
           #color: "slate"
 
+## headers (list of headers)
+## Description:
+##   HTTP headers to add to the response
+##   When this section is omitted, the following headers are added by default:
+##   - X-Forwarded-User
+##   - X-Forwarded-Displayname
+##   - X-Authenticated-User
+#headers:
+#  -
+#    ## headers.$.name (string)
+#    ## Description:
+#    ##   Name of the header.
+#    ## Required
+#    name: "X-Forwarded-User"
+
+#    ## headers.$.value (string)
+#    ## Description:
+#    ##   Value of the header.
+#    ##   The value is evaluated as a Go template.
+#    ## Required
+#    value: '{{ .Claim "id" | default "" }}'
+

--- a/docs/03-all-configuration-options.md
+++ b/docs/03-all-configuration-options.md
@@ -287,4 +287,11 @@ portals:
           #color: "slate"
 ```
 
+## Header configuration
+
+| Name | Type | Description | |
+| --- | --- | --- | --- |
+| <a id="config-opt-headers-headers-$-name"></a>`headers.$.name` | string | Name of the header.| **Required** |
+| <a id="config-opt-headers-headers-$-value"></a>`headers.$.value` | string | Value of the header.<br>The value is evaluated as a Go template.| **Required** |
+
 <!-- END CONFIG TABLE -->

--- a/docs/07-advanced-configuration.md
+++ b/docs/07-advanced-configuration.md
@@ -65,6 +65,32 @@ By default, sessions are valid for 2 hours.
 
 You can configure the lifetime of a session using the option [`tokens.sessionLifetime`](./03-all-configuration-options.md#config-opt-tokens-sessionlifetime), which accepts a Go duration (such as `2h` for 2 hours, or `30m` for 30 minutes).
 
+## Configure headers
+
+By default, Traefik Forward Auth adds the following headers to its response:
+
+- `X-Forwarded-User`: the user identifier
+- `X-Forwarded-Displayname`: the user name
+- `X-Authenticated-User`: a JSON object that includes the user ID, the portal's name, and the provider's name.
+
+You may overwrite those headers by adding the `headers` section to the configuration:
+
+```yaml
+headers:
+- name: X-Forwarded-Email
+  value: '{{ .Claim "email" | safeToLower }}'
+```
+
+The header values are interpreted Go templates. In the templates, you may use template functions provided by [Sprout](https://docs.atom.codes/sprout/groups/hermetic), and you have access to the following built-in values:
+
+| Template                       | Description                                                                              |
+|--------------------------------|------------------------------------------------------------------------------------------|
+| `{{ .Claim "$" }}`             | One of the claims returned by the identity provider (replace `$` with name of the claim) |
+| `{{ .Portal.Name }}`           | The name of the authentication portal                                                    |
+| `{{ .Portal.DisplayName }} `   | The display name of the authentication portal                                            |
+| `{{ .Provider.Name }}`         | The name of the identity provider                                                        |
+| `{{ .Provider.DisplayName }} ` | The display name of the identity provider                                                |
+
 ## Security hardening
 
 This section contains some advanced options to harden the security of Traefik Forward Auth.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/gin-gonic/gin v1.12.0
+	github.com/go-sprout/sprout v1.0.3
 	github.com/google/uuid v1.6.0
 	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c
 	github.com/italypaleale/go-kit v0.0.0-20260326154118-cba072650bb2
@@ -39,9 +40,11 @@ require (
 )
 
 require (
+	dario.cat/mergo v1.0.2 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
@@ -84,7 +87,9 @@ require (
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 // indirect
 	github.com/mdlayher/socket v0.5.0 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 h1:fou+2+WFTib47nS+nz/ozhEBnvU96bKHy6LjRsY4E28=
@@ -12,6 +14,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/akutz/memconn v0.1.0 h1:NawI0TORU4hcOMsMr11g7vwlCdkYeLKXBcxWu2W/P8A=
 github.com/akutz/memconn v0.1.0/go.mod h1:Jo8rI7m0NieZyLI5e2CDlRdRqRRB4S7Xp77ukDjH+Fw=
 github.com/alphadose/haxmap v1.4.1 h1:VtD6VCxUkjNIfJk/aWdYFfOzrRddDFjmvmRmILg7x8Q=
@@ -76,6 +80,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.30.1 h1:f3zDSN/zOma+w6+1Wswgd9fLkdwy06ntQJp0BBvFG0w=
 github.com/go-playground/validator/v10 v10.30.1/go.mod h1:oSuBIQzuJxL//3MelwSLD5hc2Tu889bF0Idm9Dg26cM=
+github.com/go-sprout/sprout v1.0.3 h1:LLuz0D3aYazgbVTOwCVuMor3LOUVYinipXRIdjA/D+I=
+github.com/go-sprout/sprout v1.0.3/go.mod h1:cFFzpnyGGry3cmN0UNCAM1f7AGok6vPVabeYQzBMBZY=
 github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
 github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
@@ -147,10 +153,14 @@ github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 h1:A1Cq6Ysb0GM0
 github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42/go.mod h1:BB4YCPDOzfy7FniQ/lxuYQ3dgmM2cZumHbK8RpTjN2o=
 github.com/mdlayher/socket v0.5.0 h1:ilICZmJcQz70vrWVes1MFera4jGiWNocSkykwwoy3XI=
 github.com/mdlayher/socket v0.5.0/go.mod h1:WkcBFfvyG8QENs5+hfQPl1X6Jpd2yeLIYgrGFmJiJxI=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -196,6 +206,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
+github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/hmac"
@@ -17,13 +18,22 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"text/template"
 	"time"
 
+	"github.com/go-sprout/sprout"
+	"github.com/go-sprout/sprout/group/hermetic"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 
 	"github.com/italypaleale/traefik-forward-auth/pkg/auth"
 	"github.com/italypaleale/traefik-forward-auth/pkg/utils"
 	"github.com/italypaleale/traefik-forward-auth/pkg/utils/validators"
+)
+
+const (
+	headerXForwardedDisplayName = "X-Forwarded-Displayname"
+	headerXForwardedUser        = "X-Forwarded-User"
+	headerXAuthenticatedUser    = "X-Authenticated-User"
 )
 
 // Config is the struct containing configuration
@@ -48,6 +58,9 @@ type Config struct {
 	// At least one configured portal and provider is required
 	// +required
 	Portals []ConfigPortal `yaml:"portals"`
+
+	// HTTP headers to add to the response
+	Headers []ConfigHeader `yaml:"headers"`
 
 	// Dev is meant for development only; it's undocumented
 	Dev ConfigDev `yaml:"dev" ignoredocs:"true"`
@@ -232,6 +245,21 @@ type ConfigPortalProvider struct {
 	configParsed ProviderConfig
 }
 
+type ConfigHeader struct {
+	// Name of the header.
+	// +required
+	// +example "X-Forwarded-User"
+	Name string `yaml:"name"`
+	// Value of the header.
+	// The value is evaluated as a Go template.
+	// +required
+	// +example '{{ .Claim "id" | default "" }}'
+	Value string `yaml:"value"`
+
+	// Parsed template - internal
+	template *template.Template
+}
+
 // ConfigDev includes options using during development only
 type ConfigDev struct {
 	// If true, disables caching on the client
@@ -381,6 +409,17 @@ func (c *Config) Validate(logger *slog.Logger) error {
 		}
 	}
 
+	// Parse headers' configuration
+	for i := range c.Headers {
+		err = c.Headers[i].Parse(c)
+		if err != nil {
+			if c.Headers[i].Name == "" {
+				return fmt.Errorf("invalid header at index %d: %w", i, err)
+			}
+			return fmt.Errorf("invalid header '%s' (at index %d): %w", c.Headers[i].Name, i, err)
+		}
+	}
+
 	return nil
 }
 
@@ -512,6 +551,41 @@ func (v *ConfigPortalProvider) Parse(c *Config) (err error) {
 	v.configParsed.SetConfigObject(c)
 
 	return nil
+}
+
+func (h *ConfigHeader) Parse(c *Config) (err error) {
+	if h.Name == "" {
+		return errors.New("property 'name' is required")
+	}
+	if h.Value == "" {
+		return errors.New("property 'value' is required")
+	}
+
+	funcs := sprout.New(
+		sprout.WithSafeFuncs(true),
+		sprout.WithGroups(hermetic.RegistryGroup()),
+	).Build()
+
+	tpl, err := template.New("").Funcs(funcs).Parse(h.Value)
+	if err != nil {
+		return fmt.Errorf("property 'value' is invalid: %w", err)
+	}
+
+	h.template = tpl
+	return nil
+}
+
+func (h *ConfigHeader) Evaluate(data any) (string, error) {
+	if h.template == nil {
+		return "", errors.New("method Parse was not called on header configuration object")
+	}
+
+	var buff bytes.Buffer
+	err := h.template.Execute(&buff, data)
+	if err != nil {
+		return "", err
+	}
+	return buff.String(), nil
 }
 
 func sanitizeProviderName(name string) (string, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -164,6 +164,21 @@ func TestValidateConfig(t *testing.T) {
 		require.Len(t, config.Portals, 1)
 		assert.EqualValues(t, expectProviderConfig, config.Portals[0].Providers[0].configParsed)
 	})
+
+	t.Run("fails when headers contain invalid template", func(t *testing.T) {
+		t.Cleanup(SetTestConfig(func(c *Config) {
+			c.Headers = []ConfigHeader{
+				{
+					Name:  "X-Forwarded-User",
+					Value: "{{ foo }}",
+				},
+			}
+		}))
+
+		err := config.Validate(log)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "function \"foo\" not defined")
+	})
 }
 
 func TestSetTokenSigningKey(t *testing.T) {

--- a/pkg/config/instance.go
+++ b/pkg/config/instance.go
@@ -49,6 +49,20 @@ func GetDefaultConfig() *Config {
 			Level:            "info",
 			OmitHealthChecks: true,
 		},
+		Headers: []ConfigHeader{
+			{
+				Name:  headerXForwardedUser,
+				Value: `{{ .Claim "id" | default "" }}`,
+			},
+			{
+				Name:  headerXForwardedDisplayName,
+				Value: `{{ .Claim "name" | default "" }}`,
+			},
+			{
+				Name:  headerXAuthenticatedUser,
+				Value: `{{ .Claim "id" | dict "provider" .Provider.Name "portal" .Portal.Name "user" | toJSON }}`,
+			},
+		},
 	}
 }
 

--- a/pkg/server/headers.go
+++ b/pkg/server/headers.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/italypaleale/traefik-forward-auth/pkg/auth"
+	"github.com/italypaleale/traefik-forward-auth/pkg/config"
+	"github.com/italypaleale/traefik-forward-auth/pkg/user"
+)
+
+type headerContext struct {
+	Portal   headerContextPortal
+	Provider headerContextProvider
+	profile  *user.Profile
+}
+
+func (c headerContext) Claim(claim string) any {
+	return c.profile.Get(claim)
+}
+
+type headerContextPortal struct {
+	Name        string
+	DisplayName string
+}
+
+type headerContextProvider struct {
+	Name        string
+	DisplayName string
+}
+
+func getHeaders(portal Portal, provider auth.Provider, profile *user.Profile) (map[string]string, error) {
+	cfg := config.Get()
+	headers := map[string]string{}
+	context := headerContext{
+		Portal: headerContextPortal{
+			Name:        portal.Name,
+			DisplayName: portal.DisplayName,
+		},
+		Provider: headerContextProvider{
+			Name:        provider.GetProviderName(),
+			DisplayName: provider.GetProviderDisplayName(),
+		},
+		profile: profile,
+	}
+
+	for _, header := range cfg.Headers {
+		value, err := header.Evaluate(context)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate header %q: %w", header.Name, err)
+		}
+		headers[header.Name] = value
+	}
+
+	return headers, nil
+}

--- a/pkg/server/routes-auth.go
+++ b/pkg/server/routes-auth.go
@@ -3,7 +3,6 @@ package server
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -110,16 +109,19 @@ func (s *Server) handleAuthenticatedRoot(c *gin.Context, portal Portal, provider
 		}
 	}
 
+	// Set headers
+	headers, err := getHeaders(portal, provider, profile)
+	if err != nil {
+		AbortWithError(c, err)
+		return
+	}
+	for name, value := range headers {
+		c.Header(name, value)
+	}
+
 	// If we are here, we have a valid session, so respond with a 200 status code
 	// Include the user name in the response body in case a visitor is hitting the auth server directly
 	s.metrics.RecordAuthentication(true)
-
-	// Set the X-Forwarded-User, X-Authenticated-User, X-Forwarded-Displayname headers
-	c.Header(headerXForwardedUser, profile.ID)
-	c.Header(headerXAuthenticatedUser, authenticatedUserFromProfile(provider, portal.Name, profile))
-	if profile.Name.FullName != "" {
-		c.Header(headerXForwardedDisplayName, profile.Name.FullName)
-	}
 
 	switch {
 	case utils.IsTruthy(c.Query("html")):
@@ -490,13 +492,6 @@ func getPortalURI(c *gin.Context, portal string) string {
 	}
 
 	return baseURI + "/portals/" + portal
-}
-
-// Returns the user information to include in the "X-Authenticated-User" header
-func authenticatedUserFromProfile(provider auth.Provider, portal string, profile *user.Profile) string {
-	userID, _ := json.Marshal(profile.ID)
-	// Provider and portal names is already guaranteed to not include characters that must be escaped as JSON
-	return `{"provider":"` + provider.GetProviderName() + `","portal":"` + portal + `","user":` + string(userID) + `}`
 }
 
 // Returns the value from the X-Forwarded-Proto header, handling WebSockets

--- a/pkg/server/routes-auth_test.go
+++ b/pkg/server/routes-auth_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -146,6 +147,99 @@ func TestServerAuthRoutes(t *testing.T) {
 	t.Run("with basePath, requesting default portal using long path", testFn("/auth/portals/test1", "/auth/portals/test1/signin", func(c *config.Config) {
 		c.Server.BasePath = "/auth"
 		c.DefaultPortal = "test1"
+	}))
+}
+
+func TestRouteGetAuthRootAuthenticated(t *testing.T) {
+	testFn := func(setConfigFn func(c *config.Config), checkResFn func(t *testing.T, res *http.Response, profile *user.Profile)) func(t *testing.T) {
+		return func(t *testing.T) {
+			if setConfigFn != nil {
+				t.Cleanup(config.SetTestConfig(setConfigFn))
+			}
+
+			// Create the server
+			srv, _ := newTestServer(t)
+			require.NotNil(t, srv)
+			stopServerFn := startTestServer(t, srv)
+			defer stopServerFn(t)
+			appClient := clientForListener(srv.appListener)
+
+			cfg := config.Get()
+			const portalName = "test1"
+
+			// Create a session token with a full profile
+			profile := createFullTestProfile()
+			token := createTestSessionToken(t, portalName, profile, time.Hour)
+			cookieName := cfg.Cookies.CookieName(portalName)
+
+			// Make a request to the /portals/:portal/profile.json endpoint
+			reqCtx, reqCancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer reqCancel()
+			req, err := http.NewRequestWithContext(reqCtx, http.MethodGet,
+				fmt.Sprintf("http://localhost:%d/portals/%s", testServerPort, portalName), nil)
+			require.NoError(t, err)
+			req.AddCookie(&http.Cookie{Name: cookieName, Value: token})
+			populateRequiredProxyHeaders(t, req)
+
+			res, err := appClient.Do(req)
+			require.NoError(t, err)
+			defer closeBody(res)
+
+			// Check the response
+			if checkResFn != nil {
+				checkResFn(t, res, profile)
+			}
+		}
+	}
+
+	t.Run("authenticated with default headers", testFn(nil, func(t *testing.T, res *http.Response, profile *user.Profile) {
+		expectedAuthenticatedUser := fmt.Sprintf(
+			`{"portal":"test1","provider":"%s","user":"%s"}`, profile.Provider, profile.ID,
+		)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, profile.ID, res.Header.Get("X-Forwarded-User"))
+		require.Equal(t, profile.Name.FullName, res.Header.Get("X-Forwarded-Displayname"))
+		require.Equal(t, expectedAuthenticatedUser, res.Header.Get("X-Authenticated-User"))
+	}))
+
+	t.Run("authenticated with custom headers", testFn(func(c *config.Config) {
+		c.Headers = []config.ConfigHeader{
+			{
+				Name:  "X-Forwarded-Email",
+				Value: `{{ .Claim "email" | safeToUpper }}`,
+			},
+			{
+				Name:  "X-Missing-With-Safe",
+				Value: `missing:{{ .Claim "missing" | safeToUpper }}`,
+			},
+			{
+				Name:  "X-Missing-With-Default",
+				Value: `missing:{{ .Claim "missing" | default "" }}`,
+			},
+			{
+				Name:  "X-Missing-Without-Default",
+				Value: `missing:{{ .Claim "missing" }}`,
+			},
+		}
+	}, func(t *testing.T, res *http.Response, profile *user.Profile) {
+		require.Equal(t, strings.ToUpper(profile.Email.Value), res.Header.Get("X-Forwarded-Email"))
+		require.Equal(t, "missing:", res.Header.Get("X-Missing-With-Safe"))
+		require.Equal(t, "missing:", res.Header.Get("X-Missing-With-Default"))
+		require.Equal(t, "missing:<no value>", res.Header.Get("X-Missing-Without-Default"))
+	}))
+
+	t.Run("authenticated with header template error", testFn(func(c *config.Config) {
+		c.Headers = []config.ConfigHeader{
+			{
+				Name:  "X-Invalid-Header",
+				Value: `{{ .Portal.MissingField }}`,
+			},
+		}
+	}, func(t *testing.T, res *http.Response, profile *user.Profile) {
+		require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "Error: An internal error occurred", string(body))
 	}))
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,18 +39,15 @@ import (
 )
 
 const (
-	headerContentType           = "Content-Type"
-	headerLocation              = "Location"
-	headerXForwardedDisplayName = "X-Forwarded-Displayname"
-	headerXForwardedFor         = "X-Forwarded-For"
-	headerXForwardedPort        = "X-Forwarded-Port"
-	headerXForwardedProto       = "X-Forwarded-Proto"
-	headerXForwardedHost        = "X-Forwarded-Host"
-	headerXForwardedServer      = "X-Forwarded-Server"
-	headerXForwardedURI         = "X-Forwarded-Uri"
-	headerXForwardedUser        = "X-Forwarded-User"
-	headerXAuthenticatedUser    = "X-Authenticated-User"
-	headerXForwardAuthIf        = "X-Forward-Auth-If"
+	headerContentType      = "Content-Type"
+	headerLocation         = "Location"
+	headerXForwardedFor    = "X-Forwarded-For"
+	headerXForwardedPort   = "X-Forwarded-Port"
+	headerXForwardedProto  = "X-Forwarded-Proto"
+	headerXForwardedHost   = "X-Forwarded-Host"
+	headerXForwardedServer = "X-Forwarded-Server"
+	headerXForwardedURI    = "X-Forwarded-Uri"
+	headerXForwardAuthIf   = "X-Forward-Auth-If"
 
 	contentTypeTextPlain = "text/plain; charset=utf-8"
 

--- a/tools/gen-config/main.go
+++ b/tools/gen-config/main.go
@@ -155,6 +155,9 @@ func processStruct(structDef structDef, yamlPrefix string, parentYamlPath string
 		printMarkdownHeader("## Portal configuration", outMD)
 	case parentYamlPath == "portals.$.providers.$" && strings.HasPrefix(sectionName, "portals.$.providers.$-"):
 		providerName = strings.TrimPrefix(sectionName, "portals.$.providers.$-")
+	case parentYamlPath == "headers.$" && sectionName == "headers":
+		fmt.Fprint(outMD, "\n")
+		printMarkdownHeader("## Header configuration", outMD)
 	}
 
 	for _, field := range structDef.StructType.Fields.List {
@@ -215,6 +218,10 @@ func processStruct(structDef structDef, yamlPrefix string, parentYamlPath string
 		// Handle the special "providers" field
 		case fullYamlPath == "portals.$.providers" && sectionName == "portals":
 			processProvidersField(outYAML, outMD, yamlPrefix)
+
+		// Handle the special "headers" field
+		case fullYamlPath == "headers" && sectionName == "":
+			processHeadersField(outYAML, outMD, yamlPrefix)
 
 		// Handle regular (non-struct) fields
 		case !isStructField:
@@ -377,6 +384,22 @@ func processPortalsField(outYAML io.Writer, outMD io.Writer, yamlPrefix string) 
 	y("  -\n")
 
 	processStruct(structTypes["ConfigPortal"], "    ", "portals.$", "portals", outYAML, outMD, false)
+}
+
+// processHeadersField handles the special "headers" field
+func processHeadersField(outYAML io.Writer, outMD io.Writer, yamlPrefix string) {
+	y := func(format string, a ...any) { fmt.Fprintf(outYAML, yamlPrefix+format, a...) }
+	y("## headers (list of headers)\n")
+	y("## Description:\n")
+	y("##   HTTP headers to add to the response\n")
+	y("##   When this section is omitted, the following headers are added by default:\n")
+	y("##   - X-Forwarded-User\n")
+	y("##   - X-Forwarded-Displayname\n")
+	y("##   - X-Authenticated-User\n")
+	y("#headers:\n")
+	y("#  -\n")
+
+	processStruct(structTypes["ConfigHeader"], "#    ", "headers.$", "headers", outYAML, outMD, false)
 }
 
 // processProvidersField handles the special "providers" field


### PR DESCRIPTION
Hello,

This PR aims to address #20 and #39.

It is inspired by Traefik OIDC Auth plugin's [header configuration](https://traefik-oidc-auth.sevensolutions.cc/docs/getting-started/middleware-configuration#header).

## Summary

Default response headers may be replaced using the `headers` configuration section.

Header values are interpreted as Go templates.

## Description

Users may now override the response headers by adding the `headers` section to the configuration.

Headers are defined as a list of `Name`/`Value` pairs, where `Name` is the name of a HTTP header and `Value` is a Go template:

```yaml
headers:
- name: X-Forwarded-Email
  value: '{{ .Claim "email" | safeToLower }}'
```

User may use any template function from [Sprout's `hermetic` registry group ](https://docs.atom.codes/sprout/groups/hermetic).

The following built-in values are exposed in the template:
| Template | Description |
|-|-|
| `{{ .Claim "$" }}` | One of the claims returned by the identity provider (replace `$` with name of the claim) |
| `{{ .Portal.Name }}` | The name of the authentication portal |
| `{{ .Portal.DisplayName }} ` | The display name of the authentication portal |
| `{{ .Provider.Name }}` | The name of the identity provider |
| `{{ .Provider.DisplayName }} ` | The display name of the identity provider |

When the `headers` section is absent, the default headers (`X-Forwarded-User`, `X-Forwarded-Displayname`, and `X-Authenticated-User`) are returned.

Those default headers are now defined as Go templates:

```yaml
- Name: X-Forwarded-User
  Value: '{{ .Claim "id" }}'
- Name: X-Forwarded-Displayname
  Value: '{{ .Claim "name" }}'
- Name: X-Authenticated-User
  Value: '{{ .Claim "id" | dict "provider" .Provider.Name "portal" .Portal.Name "user" | toJSON }}'
```

## Use cases

Here are some use cases that may be implemented using custom headers.

### Changing the header name

```yaml
- Name: Es-Security-RunAs-User # For ECK
  Value: '{{ .Claim "id" }}'
```

### Using a different claim to identify the user

```yaml
- Name: X-Forwarded-User # Note: preferred_username is not supported at the moment
  Value: '{{ .Claim "preferred_username" }}'
```

```yaml
- Name: X-Forwarded-User # the email address, only if verified
  Value: '{{ .Claim "email_verified" | ternary (.Claim "email") "anonymous" }}'
```

### Normalizing the email address

```yaml
- Name: X-Forwarded-Email # the email address, lowercased
  Value: '{{ .Claim "email" | safeToLower }}'
```

### Mapping users

```yaml
- Name: X-Forwarded-User # map UUIDs to usernames
  Value: '{{ dict "658855d4-619a-4465-95a2-fc02d4653fde" "tom" "af5520cb-db56-4d63-9a54-7d24fe507005" "jerry" | get (.Claim "id") | default "anonymous" }}'
```

## Impact for current users

When the `headers` section is omitted (which is the default in `config.sample.yaml`), Traefik Forward Auth returns the default headers. The only noticeable change is the order of the keys in the `X-Authenticated-User` header which are now in alphabetical order (previously `provider`/`portal`/`user`, now `portal`/`provider`/`user`).

## Error handling

The following errors may occur:
* Missing header name: When a header name is missing, the configuration validation will fail at startup.
* Invalid template: When a template contains a syntax error or uses an unknown function, the configuration validation will fail at startup.
* Template execution error: When a template fails to render (which happens when a function receives incorrect arguments), the server will log the error and return `500 Server Error`. This may be avoided by using [Safe functions](https://docs.atom.codes/sprout/features/safe-functions).

## Security implications

As a general rule, users shouldn't get their configuration from an untrusted source. Nonetheless, Sprout functions are guaranteed not to panic and [the `hermetic` registry group ](https://docs.atom.codes/sprout/groups/hermetic) excludes deprecated functions, experimental functions, and functions that depend on external services or are influenced by the environment where the application is running. Therefore, executing a template shouldn't cause the application to crash or leak any information.

## Alternatives considered

### Not using Go templates

I considered using a simple mapping  from HTTP header names to ID token claims, like the [Traefik OIDC middleware does](https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/oidc/#opt-forwardHeaders). That would have made the configuration and implementation simpler. However, that would also have left the `X-Authenticated-User` header as a special case.

Go templates should be easy to adopt for users who are already familiar with [Helm](https://helm.sh/docs/chart_best_practices/templates/).

### Not using a template function library

The `toJSON` function is needed in order to implement the `X-Authenticated-User` header. The `dict` function, while not strictly necessary, makes the template easier to write. Other functions such as `toLower`/`safeToLower` might be useful if the user wants to normalize values. I didn't want to re-invente the wheel, so I opted to use Sprout, which is a modernized, maintained, and performant template function library.

### Exposing claims as a dictionary

`.Claim` is a function that takes an ID token claim name and returns its value. I considered including `.Claims` as a dictionary/map of all the claims. However, we currently don't have a convenient method to enumerate all the claims in the `user.Profile`.

### Not failing on template errors

Rather than returning `500 Server Error` when a template fails to render, we could simply ignore the error and remove the header. However failing silently means errors can go undetected. It's better to fail early and annoy a few users than hiding a potential security issue.

### Configuring headers on the portal

Headers are configured globally. Would it make more sense to configure them on the portal? Maybe. I don't really have a preference. I chose to configure headers globally because that was easier to implement.