### PR TITLE
docs: add full YAML configuration examples to provider pages

### DIFF
--- a/docs/content/providers/github.md
+++ b/docs/content/providers/github.md
@@ -11,7 +11,7 @@ Configure a provider with these options in the `github` property:
 
 ## Full configuration example
 
-The following is a complete `tfa-config.yaml` example using GitHub as the authentication provider. Required options are populated, while optional ones are commented out.
+The following is a complete `tfa-config.yaml` example using GitHub as the authentication provider.
 
 ```yaml
 # tfa-config.yaml
@@ -26,12 +26,10 @@ server:
 portals:
   - name: "main"
     providers:
-      - # Configure authentication with GitHub
-        github:
+      # Configure authentication with GitHub
+      - github:
           clientID: "your-client-id"
           clientSecret: "your-client-secret"
-          # Alternative to `clientSecret`: load the secret from a file
-          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/github/client-secret"
 ```
 
-[Full list of configuration options for GitHub and example](/advanced/all-configuration-options#using-github)
+[Full list of configuration options for GitHub](/advanced/all-configuration-options#using-github)

--- a/docs/content/providers/github.md
+++ b/docs/content/providers/github.md
@@ -9,4 +9,29 @@ Configure a provider with these options in the `github` property:
 - [`clientID`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-github-portals-$-providers-$-github-clientid): OAuth2 client ID of your application
 - [`clientSecret`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-github-portals-$-providers-$-github-clientsecret): OAuth2 client secret of your application
 
+## Full configuration example
+
+The following is a complete `tfa-config.yaml` example using GitHub as the authentication provider. Required options are populated, while optional ones are commented out.
+
+```yaml
+# tfa-config.yaml
+server:
+  # Domain(s) served by Traefik Forward Auth
+  # `domain` is the cookie domain (the domain where the app is reachable, or a parent domain)
+  # `authHost` is the public hostname of Traefik Forward Auth itself (omit it when using "sub-path" mode)
+  domains:
+    - domain: "example.com"
+      authHost: "auth.example.com"
+
+portals:
+  - name: "main"
+    providers:
+      - # Configure authentication with GitHub
+        github:
+          clientID: "your-client-id"
+          clientSecret: "your-client-secret"
+          # Alternative to `clientSecret`: load the secret from a file
+          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/github/client-secret"
+```
+
 [Full list of configuration options for GitHub and example](/advanced/all-configuration-options#using-github)

--- a/docs/content/providers/google.md
+++ b/docs/content/providers/google.md
@@ -11,8 +11,7 @@ Configure a provider with these options in the `google` property:
 
 ## Full configuration example
 
-The following is a complete `tfa-config.yaml` example using Google as the authentication provider. Required options are populated, while optional ones are commented out.
-
+The following is a complete `tfa-config.yaml` example using Google as the authentication provider.
 ```yaml
 # tfa-config.yaml
 server:
@@ -26,12 +25,10 @@ server:
 portals:
   - name: "main"
     providers:
-      - # Configure authentication with Google
-        google:
+      # Configure authentication with Google
+      - google:
           clientID: "your-google-client-id.apps.googleusercontent.com"
           clientSecret: "your-client-secret"
-          # Alternative to `clientSecret`: load the secret from a file
-          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/google/client-secret"
 ```
 
-[Full list of configuration options for Google and example](/advanced/all-configuration-options#using-google)
+[Full list of configuration options for Google](/advanced/all-configuration-options#using-google)

--- a/docs/content/providers/google.md
+++ b/docs/content/providers/google.md
@@ -9,4 +9,29 @@ Configure a provider with these options in the `google` property:
 - [`clientID`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-google-portals-$-providers-$-google-clientid): OAuth2 client ID of your application
 - [`clientSecret`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-google-portals-$-providers-$-google-clientsecret): OAuth2 client secret of your application
 
+## Full configuration example
+
+The following is a complete `tfa-config.yaml` example using Google as the authentication provider. Required options are populated, while optional ones are commented out.
+
+```yaml
+# tfa-config.yaml
+server:
+  # Domain(s) served by Traefik Forward Auth
+  # `domain` is the cookie domain (the domain where the app is reachable, or a parent domain)
+  # `authHost` is the public hostname of Traefik Forward Auth itself (omit it when using "sub-path" mode)
+  domains:
+    - domain: "example.com"
+      authHost: "auth.example.com"
+
+portals:
+  - name: "main"
+    providers:
+      - # Configure authentication with Google
+        google:
+          clientID: "your-google-client-id.apps.googleusercontent.com"
+          clientSecret: "your-client-secret"
+          # Alternative to `clientSecret`: load the secret from a file
+          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/google/client-secret"
+```
+
 [Full list of configuration options for Google and example](/advanced/all-configuration-options#using-google)

--- a/docs/content/providers/microsoft-entra-id.md
+++ b/docs/content/providers/microsoft-entra-id.md
@@ -10,6 +10,35 @@ Configure a provider with these options in the `microsoftEntraID` property:
 - [`clientID`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-microsoftentraid-portals-$-providers-$-microsoftentraid-clientid): Client ID of your application
 - [`clientSecret`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-microsoftentraid-portals-$-providers-$-microsoftentraid-clientsecret): Client secret of your application
 
+## Full configuration example
+
+The following is a complete `tfa-config.yaml` example using Microsoft Entra ID as the authentication provider. Required options are populated, while optional ones (including the recommended `clientAssertion` for Federated Identity Credentials) are commented out.
+
+```yaml
+# tfa-config.yaml
+server:
+  # Domain(s) served by Traefik Forward Auth
+  # `domain` is the cookie domain (the domain where the app is reachable, or a parent domain)
+  # `authHost` is the public hostname of Traefik Forward Auth itself (omit it when using "sub-path" mode)
+  domains:
+    - domain: "example.com"
+      authHost: "auth.example.com"
+
+portals:
+  - name: "main"
+    providers:
+      - # Configure authentication with Microsoft Entra ID
+        microsoftEntraID:
+          tenantID: "your-tenant-id"
+          clientID: "your-client-id"
+          clientSecret: "your-client-secret"
+          # Alternative to `clientSecret`: load the secret from a file
+          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/microsoft-entra-id/client-secret"
+          # Recommended on supported platforms: use a Federated Identity Credential instead of `clientSecret`
+          # See "Using Federated Identity Credentials" below for details
+          # clientAssertion: "AzureManagedIdentity"
+```
+
 [Full list of configuration options for Microsoft Entra ID and example](/advanced/all-configuration-options#using-microsoftentraid)
 
 ## Using Federated Identity Credentials

--- a/docs/content/providers/microsoft-entra-id.md
+++ b/docs/content/providers/microsoft-entra-id.md
@@ -12,7 +12,7 @@ Configure a provider with these options in the `microsoftEntraID` property:
 
 ## Full configuration example
 
-The following is a complete `tfa-config.yaml` example using Microsoft Entra ID as the authentication provider. Required options are populated, while optional ones (including the recommended `clientAssertion` for Federated Identity Credentials) are commented out.
+The following is a complete `tfa-config.yaml` example using Microsoft Entra ID as the authentication provider.
 
 ```yaml
 # tfa-config.yaml
@@ -27,19 +27,18 @@ server:
 portals:
   - name: "main"
     providers:
-      - # Configure authentication with Microsoft Entra ID
-        microsoftEntraID:
+      # Configure authentication with Microsoft Entra ID
+      - microsoftEntraID:
           tenantID: "your-tenant-id"
           clientID: "your-client-id"
           clientSecret: "your-client-secret"
-          # Alternative to `clientSecret`: load the secret from a file
-          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/microsoft-entra-id/client-secret"
+
           # Recommended on supported platforms: use a Federated Identity Credential instead of `clientSecret`
           # See "Using Federated Identity Credentials" below for details
-          # clientAssertion: "AzureManagedIdentity"
+          #clientAssertion: "AzureManagedIdentity"
 ```
 
-[Full list of configuration options for Microsoft Entra ID and example](/advanced/all-configuration-options#using-microsoftentraid)
+[Full list of configuration options for Microsoft Entra ID](/advanced/all-configuration-options#using-microsoftentraid)
 
 ## Using Federated Identity Credentials
 

--- a/docs/content/providers/openid-connect.md
+++ b/docs/content/providers/openid-connect.md
@@ -22,7 +22,7 @@ The OpenID Connect provider supports additional configuration options that can b
 
 ## Full configuration example
 
-The following is a complete `tfa-config.yaml` example using a generic OpenID Connect provider. Required options are populated, while optional ones (including the additional TLS configuration options) are commented out.
+The following is a complete `tfa-config.yaml` example using a generic OpenID Connect provider.
 
 ```yaml
 # tfa-config.yaml
@@ -37,17 +37,16 @@ server:
 portals:
   - name: "main"
     providers:
-      - # Configure authentication with OpenID Connect
-        openIDConnect:
+      # Configure authentication with OpenID Connect
+      - openIDConnect:
           tokenIssuer: "https://tenant.identityprovider.com"
           clientID: "your-client-id"
           clientSecret: "your-client-secret"
-          # Alternative to `clientSecret`: load the secret from a file
-          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/openidconnect/client-secret"
+
           # Optional: TLS configuration for communicating with the Identity Provider
-          # tlsInsecureSkipVerify: false
-          # tlsCACertificatePEM: ""
-          # tlsCACertificatePath: ""
+          #tlsInsecureSkipVerify: false
+          #tlsCACertificatePEM: ""
+          #tlsCACertificatePath: ""
 ```
 
-[Full list of configuration options for OpenID Connect and example](/advanced/all-configuration-options#using-openid-connect)
+[Full list of configuration options for OpenID Connect](/advanced/all-configuration-options#using-openid-connect)

--- a/docs/content/providers/openid-connect.md
+++ b/docs/content/providers/openid-connect.md
@@ -20,4 +20,34 @@ The OpenID Connect provider supports additional configuration options that can b
 - [`tlsCACertificatePEM`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-openidconnect-portals-$-providers-$-openidconnect-tlscacertificatepem): PEM-encoded CA certificate used when communicating with the Identity Provider.
 - [`tlsCACertificatepath`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-openidconnect-portals-$-providers-$-openidconnect-tlscacertificatepath): Path to a file containing the PEM-encoded CA certificate used when communicating with the Identity Provider.
 
+## Full configuration example
+
+The following is a complete `tfa-config.yaml` example using a generic OpenID Connect provider. Required options are populated, while optional ones (including the additional TLS configuration options) are commented out.
+
+```yaml
+# tfa-config.yaml
+server:
+  # Domain(s) served by Traefik Forward Auth
+  # `domain` is the cookie domain (the domain where the app is reachable, or a parent domain)
+  # `authHost` is the public hostname of Traefik Forward Auth itself (omit it when using "sub-path" mode)
+  domains:
+    - domain: "example.com"
+      authHost: "auth.example.com"
+
+portals:
+  - name: "main"
+    providers:
+      - # Configure authentication with OpenID Connect
+        openIDConnect:
+          tokenIssuer: "https://tenant.identityprovider.com"
+          clientID: "your-client-id"
+          clientSecret: "your-client-secret"
+          # Alternative to `clientSecret`: load the secret from a file
+          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/openidconnect/client-secret"
+          # Optional: TLS configuration for communicating with the Identity Provider
+          # tlsInsecureSkipVerify: false
+          # tlsCACertificatePEM: ""
+          # tlsCACertificatePath: ""
+```
+
 [Full list of configuration options for OpenID Connect and example](/advanced/all-configuration-options#using-openid-connect)

--- a/docs/content/providers/pocket-id.md
+++ b/docs/content/providers/pocket-id.md
@@ -19,7 +19,7 @@ The Pocket ID provider supports additional configuration options that can be hel
 
 ## Full configuration example
 
-The following is a complete `tfa-config.yaml` example using Pocket ID as the authentication provider. Required options are populated, while optional ones (including the recommended `clientAssertion` for Federated Client Credentials and the additional TLS configuration options) are commented out.
+The following is a complete `tfa-config.yaml` example using Pocket ID as the authentication provider.
 
 ```yaml
 # tfa-config.yaml
@@ -34,23 +34,23 @@ server:
 portals:
   - name: "main"
     providers:
-      - # Configure authentication with Pocket ID
-        pocketID:
+      # Configure authentication with Pocket ID
+      - pocketID:
           endpoint: "https://pocketidid.example.com"
           clientID: "your-client-id"
           clientSecret: "your-client-secret"
-          # Alternative to `clientSecret`: load the secret from a file
-          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/pocketid/client-secret"
+
           # Recommended on supported platforms: use a Federated Client Credential instead of `clientSecret`
           # See "Using Federated Client Credentials" below for details
-          # clientAssertion: "AzureManagedIdentity"
+          #clientAssertion: "AzureManagedIdentity"
+
           # Optional: TLS configuration for communicating with Pocket ID
-          # tlsInsecureSkipVerify: false
-          # tlsCACertificatePEM: ""
-          # tlsCACertificatePath: ""
+          #tlsInsecureSkipVerify: false
+          #tlsCACertificatePEM: ""
+          #tlsCACertificatePath: ""
 ```
 
-[Full list of configuration options for Pocket ID and example](/advanced/all-configuration-options#using-pocketID)
+[Full list of configuration options for Pocket ID](/advanced/all-configuration-options#using-pocketID)
 
 ## Using Federated Client Credentials
 

--- a/docs/content/providers/pocket-id.md
+++ b/docs/content/providers/pocket-id.md
@@ -17,6 +17,39 @@ The Pocket ID provider supports additional configuration options that can be hel
 - [`tlsCACertificatePEM`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-pocketID-portals-$-providers-$-pocketID-tlscacertificatepem): PEM-encoded CA certificate used when communicating with Pocket ID.
 - [`tlsCACertificatepath`](/advanced/all-configuration-options#config-opt-portals.$.providers.$-pocketID-portals-$-providers-$-pocketID-tlscacertificatepath): Path to a file containing the PEM-encoded CA certificate used when communicating with Pocket ID.
 
+## Full configuration example
+
+The following is a complete `tfa-config.yaml` example using Pocket ID as the authentication provider. Required options are populated, while optional ones (including the recommended `clientAssertion` for Federated Client Credentials and the additional TLS configuration options) are commented out.
+
+```yaml
+# tfa-config.yaml
+server:
+  # Domain(s) served by Traefik Forward Auth
+  # `domain` is the cookie domain (the domain where the app is reachable, or a parent domain)
+  # `authHost` is the public hostname of Traefik Forward Auth itself (omit it when using "sub-path" mode)
+  domains:
+    - domain: "example.com"
+      authHost: "auth.example.com"
+
+portals:
+  - name: "main"
+    providers:
+      - # Configure authentication with Pocket ID
+        pocketID:
+          endpoint: "https://pocketidid.example.com"
+          clientID: "your-client-id"
+          clientSecret: "your-client-secret"
+          # Alternative to `clientSecret`: load the secret from a file
+          # clientSecretFile: "/var/run/secrets/traefik-forward-auth/pocketid/client-secret"
+          # Recommended on supported platforms: use a Federated Client Credential instead of `clientSecret`
+          # See "Using Federated Client Credentials" below for details
+          # clientAssertion: "AzureManagedIdentity"
+          # Optional: TLS configuration for communicating with Pocket ID
+          # tlsInsecureSkipVerify: false
+          # tlsCACertificatePEM: ""
+          # tlsCACertificatePath: ""
+```
+
 [Full list of configuration options for Pocket ID and example](/advanced/all-configuration-options#using-pocketID)
 
 ## Using Federated Client Credentials

--- a/docs/content/providers/tailscale-whois.md
+++ b/docs/content/providers/tailscale-whois.md
@@ -37,7 +37,7 @@ The session tokens issued by Traefik Forward Auth will then include a claim `{"i
 
 ## Full configuration example
 
-The following is a complete `tfa-config.yaml` example using Tailscale Whois as the authentication provider. The `tailscaleWhois` provider has no required options; the optional ones listed above are commented out.
+The following is a complete `tfa-config.yaml` example using Tailscale Whois as the authentication provider. The `tailscaleWhois` provider has no required options, so an empty object like `tailscaleWhois: {}` can be sufficient.
 
 ```yaml
 # tfa-config.yaml
@@ -52,8 +52,8 @@ server:
 portals:
   - name: "main"
     providers:
-      - # Configure authentication with Tailscale Whois
-        tailscaleWhois:
+      # Configure authentication with Tailscale Whois
+      -  tailscaleWhois:
           # Optional: restrict to a specific Tailnet only
           # allowedTailnet: "yourtailnet.ts.net"
           # Optional: customize the names of the capabilities to read from Tailscale peer capabilities

--- a/docs/content/providers/tailscale-whois.md
+++ b/docs/content/providers/tailscale-whois.md
@@ -37,7 +37,9 @@ The session tokens issued by Traefik Forward Auth will then include a claim `{"i
 
 ## Full configuration example
 
-The following is a complete `tfa-config.yaml` example using Tailscale Whois as the authentication provider. The `tailscaleWhois` provider has no required options, so an empty object like `tailscaleWhois: {}` can be sufficient.
+The following is a complete `tfa-config.yaml` example using Tailscale Whois as the authentication provider.
+
+The `tailscaleWhois` provider has no required options, so an empty object like `tailscaleWhois: {}` is sufficient in many cases.
 
 ```yaml
 # tfa-config.yaml

--- a/docs/content/providers/tailscale-whois.md
+++ b/docs/content/providers/tailscale-whois.md
@@ -35,4 +35,29 @@ For example, you can assign app capabilities to a node by listing them in your A
 
 The session tokens issued by Traefik Forward Auth will then include a claim `{"italypaleale.me/traefik-forward-auth": [ { ... }, { ... } ]}`.
 
+## Full configuration example
+
+The following is a complete `tfa-config.yaml` example using Tailscale Whois as the authentication provider. The `tailscaleWhois` provider has no required options; the optional ones listed above are commented out.
+
+```yaml
+# tfa-config.yaml
+server:
+  # Domain(s) served by Traefik Forward Auth
+  # `domain` is the cookie domain (the domain where the app is reachable, or a parent domain)
+  # `authHost` is the public hostname of Traefik Forward Auth itself (omit it when using "sub-path" mode)
+  domains:
+    - domain: "example.com"
+      authHost: "auth.example.com"
+
+portals:
+  - name: "main"
+    providers:
+      - # Configure authentication with Tailscale Whois
+        tailscaleWhois:
+          # Optional: restrict to a specific Tailnet only
+          # allowedTailnet: "yourtailnet.ts.net"
+          # Optional: customize the names of the capabilities to read from Tailscale peer capabilities
+          # capabilityNames: ["italypaleale.me/traefik-forward-auth"]
+```
+
 [Full list of configuration options for Tailscale Whois and example](/advanced/all-configuration-options#using-tailscale-whois)


### PR DESCRIPTION
Each provider documentation page now includes a complete `tfa-config.yaml`
example showing required options populated and optional/recommended ones
commented out, so users can copy-paste a working starting point without
cross-referencing the all-configuration-options page.