### PR TITLE
chore: update hugo-assets to v0.2.1

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -4,4 +4,4 @@ go 1.26.3
 
 tool github.com/italypaleale/hugo-assets/cmd/vercel-docs-build
 
-require github.com/italypaleale/hugo-assets v0.2.0 // indirect
+require github.com/italypaleale/hugo-assets v0.2.1 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/italypaleale/hugo-assets v0.2.0 h1:1xdkgmKW/x9PnglGTn7NsQ6HxDj1CmCk0ImoBC9wsnc=
-github.com/italypaleale/hugo-assets v0.2.0/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=
+github.com/italypaleale/hugo-assets v0.2.1 h1:K38hh3IVGhbevWg16r4EKb9fgfkKERRkH590yve/rII=
+github.com/italypaleale/hugo-assets v0.2.1/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=


### PR DESCRIPTION
Updates the pinned `hugo-assets` version in `docs/go.mod` and `docs/go.sum` from v0.2.0 to v0.2.1 (commit `655995121ab88ab296eadce0583290126eece7aa`).\n\nRelease: https://github.com/ItalyPaleAle/hugo-assets/releases/tag/v0.2.1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNqqXBE2a9Yr5ijQtXgp3m)_