### PR TITLE
chore: update hugo-assets to v0.2.2

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -4,4 +4,4 @@ go 1.26.3
 
 tool github.com/italypaleale/hugo-assets/cmd/vercel-docs-build
 
-require github.com/italypaleale/hugo-assets v0.2.1 // indirect
+require github.com/italypaleale/hugo-assets v0.2.2 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/italypaleale/hugo-assets v0.2.1 h1:K38hh3IVGhbevWg16r4EKb9fgfkKERRkH590yve/rII=
-github.com/italypaleale/hugo-assets v0.2.1/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=
+github.com/italypaleale/hugo-assets v0.2.2 h1:hm8DNxklpZvUnkirRdgCsCCndZ0P1Mp4dRGjWV5OqrY=
+github.com/italypaleale/hugo-assets v0.2.2/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=


### PR DESCRIPTION
Updates the pinned `hugo-assets` version in `docs/go.mod` and `docs/go.sum` from `v0.2.1` to `v0.2.2` (commit `6dd0196540deecb51e1cfe97c28f1459c2b50699`).

**Release notes for v0.2.2:**
- Set `trailingSlash` to `true` by default in builder-managed `vercel.json`

No migration steps required for this release.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZcoriEfXTzGdswWcCTCuL)_