### PR TITLE
chore: update hugo-assets to v0.4.0

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -4,4 +4,4 @@ go 1.26.3
 
 tool github.com/italypaleale/hugo-assets/cmd/vercel-docs-build
 
-require github.com/italypaleale/hugo-assets v0.3.2 // indirect
+require github.com/italypaleale/hugo-assets v0.4.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/italypaleale/hugo-assets v0.3.2 h1:smWhO8H9YKak5bbxK4fmFC8flM1JqDIG8i2GhMsImmg=
-github.com/italypaleale/hugo-assets v0.3.2/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=
+github.com/italypaleale/hugo-assets v0.4.0 h1:l4fl7tWJzWycUuuS0DZrTnlRbCFRsoFiYkJTMTiQsj4=
+github.com/italypaleale/hugo-assets v0.4.0/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=


### PR DESCRIPTION
## Summary
- Bumps the pinned `hugo-assets` dependency in `docs/go.mod` / `docs/go.sum` from `v0.3.2` to `v0.4.0` (commit [`516ef57`](https://github.com/ItalyPaleAle/hugo-assets/commit/516ef57380037feee078c4677f7e8a28068ed12f), tag [`v0.4.0`](https://github.com/ItalyPaleAle/hugo-assets/releases/tag/v0.4.0))
- Release notes: Markdown content negotiation improvements, improved 404 handling
- No other changes needed: this site is generated from `config.json`, and the release notes state that config.json-based setups require no manual changes for this upgrade (the manual `hugo.toml` note only applies to hand-maintained `hugo.toml` files)

## Test plan
- [ ] CI build passes
- [ ] Site builds and deploys correctly on Vercel

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJthREPBUrC3fAs162jkBJ)_